### PR TITLE
update cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,8 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
-##project
 project(openfec C)
 
 ENABLE_TESTING()
-
-if (PROFILING STREQUAL "ON")
-
-else(PROFILING STREQUAL "ON")
-
-endif(PROFILING STREQUAL "ON")
-
-if (DEBUG STREQUAL "ON")
-# Debug mode
-ADD_DEFINITIONS(-DOF_DEBUG)
-set(CMAKE_BUILD_TYPE Debug) 
-message(STATUS "Debug mode ON" )
-
-else(DEBUG STREQUAL "ON")
-# Release mode
-set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_C_FLAGS "-O4")
-message(STATUS "Debug mode OFF")
-
-endif (DEBUG STREQUAL "ON")
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE})
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,7 @@
 file (GLOB_RECURSE openfec_sources *)
 
-# Use -DBUILD_STATIC_LIBS=ON to build static libraries instead of shared.
-option(BUILD_STATIC_LIBS "Build the static library" OFF)
-
-if(BUILD_STATIC_LIBS)
-  add_library(openfec STATIC ${openfec_sources})
-else(BUILD_STATIC_LIBS)
-  add_library(openfec SHARED ${openfec_sources})
-endif(BUILD_STATIC_LIBS)
+add_library(openfec ${openfec_sources})
+target_compile_definitions(openfec PUBLIC $<$<CONFIG:Debug>:OF_DEBUG>)
 
 # From: $cmake --help-property SOVERSION
 #		For shared libraries VERSION and SOVERSION can be used to specify


### PR DESCRIPTION
- option 'BUILD_STATIC_LIBS' can be removed, cmake already have `BUILD_SHARED_LIBS`(ON by default)
Use `-DBUILD_SHARED_LIBS=OFF` if you want build static lib
- remove erasing C_FLAGS on release build. There is no 'O4' optimization level in gcc/clang and cmake already have preconfigured C_FLAGS for Release/Debug/etc builds.
- 'OF_DEBUG' define move to 'openfec' target and will be derived by linking this target in debug build only